### PR TITLE
fix: guard inventory stock decrease validations

### DIFF
--- a/src/main/java/com/sivalabs/bookstore/inventory/domain/InsufficientInventoryException.java
+++ b/src/main/java/com/sivalabs/bookstore/inventory/domain/InsufficientInventoryException.java
@@ -1,0 +1,7 @@
+package com.sivalabs.bookstore.inventory.domain;
+
+public class InsufficientInventoryException extends InventoryException {
+    public InsufficientInventoryException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sivalabs/bookstore/inventory/domain/InvalidInventoryAdjustmentException.java
+++ b/src/main/java/com/sivalabs/bookstore/inventory/domain/InvalidInventoryAdjustmentException.java
@@ -1,0 +1,7 @@
+package com.sivalabs.bookstore.inventory.domain;
+
+public class InvalidInventoryAdjustmentException extends InventoryException {
+    public InvalidInventoryAdjustmentException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sivalabs/bookstore/inventory/domain/InventoryException.java
+++ b/src/main/java/com/sivalabs/bookstore/inventory/domain/InventoryException.java
@@ -1,0 +1,7 @@
+package com.sivalabs.bookstore.inventory.domain;
+
+public class InventoryException extends RuntimeException {
+    public InventoryException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sivalabs/bookstore/inventory/domain/InventoryService.java
+++ b/src/main/java/com/sivalabs/bookstore/inventory/domain/InventoryService.java
@@ -40,6 +40,15 @@ public class InventoryService {
     public void decreaseStockLevel(String productCode, int quantity) {
         log.info("Decrease stock level for product code {} and quantity {}", productCode, quantity);
 
+        if (quantity <= 0) {
+            log.warn(
+                    "Rejecting inventory decrease for product code {} due to non-positive quantity: {}",
+                    productCode,
+                    quantity);
+            throw new InvalidInventoryAdjustmentException(
+                    "Quantity to decrease must be greater than zero. Provided: " + quantity);
+        }
+
         // Find inventory record - use cache if available with database fallback
         Optional<InventoryEntity> inventoryOpt;
         if (isCacheAvailable()) {
@@ -60,7 +69,23 @@ public class InventoryService {
 
         if (inventoryOpt.isPresent()) {
             InventoryEntity inventory = inventoryOpt.get();
-            long newQuantity = inventory.getQuantity() - quantity;
+            long currentQuantity = inventory.getQuantity();
+            long newQuantity = currentQuantity - quantity;
+
+            if (newQuantity < 0) {
+                log.warn(
+                        "Insufficient inventory for product code {}. Available: {}, requested decrease: {}",
+                        productCode,
+                        currentQuantity,
+                        quantity);
+                throw new InsufficientInventoryException(
+                        "Insufficient stock for product code "
+                                + productCode
+                                + ". Available: "
+                                + currentQuantity
+                                + ", requested: "
+                                + quantity);
+            }
             inventory.setQuantity(newQuantity);
 
             // Save to database first

--- a/src/test/java/com/sivalabs/bookstore/inventory/domain/InventoryServiceStockAdjustmentTests.java
+++ b/src/test/java/com/sivalabs/bookstore/inventory/domain/InventoryServiceStockAdjustmentTests.java
@@ -1,0 +1,75 @@
+package com.sivalabs.bookstore.inventory.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InventoryServiceStockAdjustmentTests {
+
+    @Mock
+    private InventoryRepository inventoryRepository;
+
+    private InventoryService inventoryService;
+
+    @BeforeEach
+    void setUp() {
+        inventoryService = new InventoryService(inventoryRepository, null);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenDecreaseQuantityExceedsAvailableStock() {
+        String productCode = "P-200";
+        InventoryEntity inventory = new InventoryEntity();
+        inventory.setProductCode(productCode);
+        inventory.setQuantity(5L);
+
+        when(inventoryRepository.findByProductCode(productCode)).thenReturn(Optional.of(inventory));
+
+        assertThatThrownBy(() -> inventoryService.decreaseStockLevel(productCode, 10))
+                .isInstanceOf(InsufficientInventoryException.class)
+                .hasMessageContaining("Insufficient stock");
+
+        assertThat(inventory.getQuantity()).isEqualTo(5L);
+        verify(inventoryRepository).findByProductCode(productCode);
+        verify(inventoryRepository, never()).save(any(InventoryEntity.class));
+    }
+
+    @Test
+    void shouldDecreaseStockWhenSufficientQuantityAvailable() {
+        String productCode = "P-300";
+        InventoryEntity inventory = new InventoryEntity();
+        inventory.setProductCode(productCode);
+        inventory.setQuantity(8L);
+
+        when(inventoryRepository.findByProductCode(productCode)).thenReturn(Optional.of(inventory));
+        when(inventoryRepository.save(inventory)).thenAnswer(invocation -> invocation.getArgument(0));
+
+        inventoryService.decreaseStockLevel(productCode, 3);
+
+        assertThat(inventory.getQuantity()).isEqualTo(5L);
+        verify(inventoryRepository).save(inventory);
+    }
+
+    @Test
+    void shouldRejectNonPositiveDecreaseQuantity() {
+        String productCode = "P-400";
+
+        assertThatThrownBy(() -> inventoryService.decreaseStockLevel(productCode, 0))
+                .isInstanceOf(InvalidInventoryAdjustmentException.class)
+                .hasMessageContaining("greater than zero");
+
+        verifyNoInteractions(inventoryRepository);
+    }
+}


### PR DESCRIPTION
## 變更摘要
- 防堵庫存扣減時的非正數輸入並針對庫存不足拋出自訂領域例外
- 新增單元測試覆蓋正常扣減與庫存不足案例，確保不會在例外狀態下寫入資料庫

## 問題描述
調整庫存扣減邏輯以避免不合法請求造成資料異常。

## 主要變更
- [x] 程式碼變更
- [ ] 設定檔調整
- [ ] 文件更新

**影響模組**：`inventory`

## 測試方式
```bash
mvn -ntp spotless:apply
mvn -ntp test
```
> 受限於執行環境無法連線至 Maven Repository（Network is unreachable），上述指令無法完成。

**測試場景**：
- [x] 正常流程
- [x] 邊界條件（如：快取關閉、資料庫斷線）
- [x] 錯誤處理

## 檢查清單
- [ ] 程式碼已格式化 (`./mvnw spotless:apply`)
- [ ] 所有測試通過 (`./mvnw clean verify`)
- [x] 無跨模組違規（遵守 Spring Modulith 邊界）
- [x] 無敏感資訊外洩

## 部署注意事項
- **資料庫異動**：無
- **設定變更**：無
- **監控指標**：無


------
https://chatgpt.com/codex/tasks/task_e_68cb6055c9848329afa48f268f0db376