### PR TITLE
Fix order templates security gaps and add rendering tests

### DIFF
--- a/src/main/resources/templates/cart.html
+++ b/src/main/resources/templates/cart.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en"
+      xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout}">
+<body>
+<div layout:fragment="content">
+    <div th:insert="~{partials/cart}"></div>
+    <div th:if="${cart != null and cart.item != null}">
+        <div class="col-md-8 offset-md-2">
+            <div th:insert="~{partials/order-form}"></div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -27,8 +27,7 @@
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
                     <li class="nav-item">
-                        <a class="nav-link" href="#"
-                           th:href="${@environment.getProperty('orders.service.ui-url', 'http://localhost:8091/orders')}">
+                        <a class="nav-link" href="/orders" th:href="@{/orders}">
                             Orders
                         </a>
                     </li>

--- a/src/main/resources/templates/order_details.html
+++ b/src/main/resources/templates/order_details.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en"
+      xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout}">
+<body>
+<div layout:fragment="content">
+    <div th:if="${order == null}">
+        <h2>We couldn't find that order.</h2>
+        <p><a th:href="@{/orders}">Return to your orders</a> or <a th:href="@{/}">keep shopping</a>.</p>
+    </div>
+    <div th:if="${order != null}">
+        <h2>Your order was placed successfully</h2>
+        <h4>Order Number: <span th:text="${order.orderNumber}">orderNumber</span></h4>
+        <h4>Order Status: <span th:text="${order.status}">status</span></h4>
+        <hr/>
+        <div class="pb-3">
+            <table class="table">
+                <thead>
+                <tr>
+                    <th scope="col">Product Name</th>
+                    <th scope="col">Price</th>
+                    <th scope="col">Quantity</th>
+                    <th scope="col">Sub Total</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td th:text="${order.item.name}">name</td>
+                    <td th:text="${order.item.price}">price</td>
+                    <td th:text="${order.item.quantity}">quantity</td>
+                    <td th:text="${order.item.quantity * order.item.price}">SubTotal</td>
+                </tr>
+                </tbody>
+                <tfoot>
+                <tr>
+                    <th colspan="3"></th>
+                    <th colspan="1" style="text-align: left">
+                        Total Amount: <span th:text="${order.totalAmount}">totalAmount</span>
+                    </th>
+                </tr>
+                </tfoot>
+            </table>
+
+            <form class="row g-3" method="post">
+                <div class="col-md-6">
+                    <label for="customerName" class="form-label">Customer Name</label>
+                    <input type="text" class="form-control"
+                           id="customerName"
+                           name="customerName"
+                           readonly
+                           aria-readonly="true"
+                           th:value="${order.customer.name}"/>
+                </div>
+                <div class="col-md-6">
+                    <label for="customerEmail" class="form-label">Customer Email</label>
+                    <input type="email" class="form-control"
+                           id="customerEmail"
+                           name="customerEmail"
+                           readonly
+                           aria-readonly="true"
+                           th:value="${order.customer.email}"/>
+                </div>
+                <div class="col-md-6">
+                    <label for="customerPhone" class="form-label">Customer Phone</label>
+                    <input type="text" class="form-control"
+                           id="customerPhone"
+                           name="customerPhone"
+                           readonly
+                           aria-readonly="true"
+                           th:value="${order.customer.phone}"/>
+                </div>
+                <div class="col-6">
+                    <label for="deliveryAddress" class="form-label">Delivery Address</label>
+                    <input class="form-control"
+                           id="deliveryAddress"
+                           name="deliveryAddress"
+                           readonly
+                           aria-readonly="true"
+                           th:value="${order.deliveryAddress}"/>
+                </div>
+
+            </form>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/orders.html
+++ b/src/main/resources/templates/orders.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en"
+      xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout}">
+
+<body>
+<div layout:fragment="content">
+    <div>
+        <h2>All Orders</h2>
+        <hr/>
+        <div class="pb-3">
+            <table class="table">
+                <thead>
+                <tr>
+                    <th scope="col">Order ID</th>
+                    <th scope="col">Status</th>
+                </tr>
+                </thead>
+                <tbody>
+                    <th:block th:insert="~{partials/orders}"/>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/partials/cart.html
+++ b/src/main/resources/templates/partials/cart.html
@@ -1,0 +1,52 @@
+<div id="cart" hx-swap-oob="true">
+    <div class="col-md-8 offset-md-2">
+        <div th:if="${cart == null}">
+            <h3>We couldn't load your cart right now. <a th:href="@{/}">Continue shopping</a></h3>
+        </div>
+        <div th:if="${cart != null and cart.item == null}">
+            <h3>Your cart is empty. <a th:href="@{/}">Continue shopping</a></h3>
+        </div>
+        <div th:if="${cart != null and cart.item != null}" class="pb-3">
+            <table class="table">
+                <thead>
+                <tr>
+                    <th scope="col">Product Name</th>
+                    <th scope="col">Price</th>
+                    <th scope="col">Quantity</th>
+                    <th scope="col">Sub Total</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td><span th:text="${cart.item.name}">Product name</span></td>
+                    <td><span th:text="${cart.item.price}">Price</span></td>
+                    <td>
+                        <form th:action="@{/update-cart}" method="post">
+                            <input type="hidden" name="code" th:value="${cart.item.code}" />
+                            <input type="number" min="1"
+                                   name="quantity"
+                                   th:value="${cart.item.quantity}"
+                                   hx-post="/update-cart"
+                                   hx-target="#cart"
+                                   hx-swap="outerHTML"
+                                   aria-label="Update quantity"
+                            />
+                        </form>
+                    </td>
+                    <td>
+                        <span th:text="${cart.item.quantity * cart.item.price}">Sub total</span>
+                    </td>
+                </tr>
+                </tbody>
+                <tfoot>
+                <tr>
+                    <th colspan="3"></th>
+                    <th colspan="1" style="text-align: left">
+                        Total Amount: <span th:text="${cart.totalAmount}">Total amount</span>
+                    </th>
+                </tr>
+                </tfoot>
+            </table>
+        </div>
+    </div>
+</div>

--- a/src/main/resources/templates/partials/order-form.html
+++ b/src/main/resources/templates/partials/order-form.html
@@ -1,0 +1,70 @@
+<form class="row g-3" method="post" th:action="@{/orders}"
+                        th:object="${orderForm}">
+    <div class="col-md-6">
+        <label for="customerName" class="form-label">Customer Name <span class="text-danger" aria-hidden="true">*</span></label>
+        <input type="text" class="form-control"
+               id="customerName"
+               name="customer.name"
+               th:field="*{customer.name}"
+               required
+               aria-required="true"
+               th:classappend="${#fields.hasErrors('customer.name')} ? 'is-invalid' : ''"/>
+        <div class="invalid-feedback"
+             id="customerNameError"
+             th:if="${#fields.hasErrors('customer.name')}"
+             th:errors="*{customer.name}">
+            Incorrect data
+        </div>
+    </div>
+    <div class="col-md-6">
+        <label for="customerEmail" class="form-label">Customer Email <span class="text-danger" aria-hidden="true">*</span></label>
+        <input type="email" class="form-control"
+               id="customerEmail"
+               name="customer.email"
+               th:field="*{customer.email}"
+               required
+               aria-required="true"
+               th:classappend="${#fields.hasErrors('customer.email')} ? 'is-invalid' : ''"/>
+        <div class="invalid-feedback"
+             id="customerEmailError"
+             th:if="${#fields.hasErrors('customer.email')}"
+             th:errors="*{customer.email}">
+            Incorrect data
+        </div>
+    </div>
+    <div class="col-md-6">
+        <label for="customerPhone" class="form-label">Customer Phone <span class="text-danger" aria-hidden="true">*</span></label>
+        <input type="text" class="form-control"
+               id="customerPhone"
+               name="customer.phone"
+               th:field="*{customer.phone}"
+               required
+               aria-required="true"
+               th:classappend="${#fields.hasErrors('customer.phone')} ? 'is-invalid' : ''"/>
+        <div class="invalid-feedback"
+             id="customerPhoneError"
+             th:if="${#fields.hasErrors('customer.phone')}"
+             th:errors="*{customer.phone}">
+            Incorrect data
+        </div>
+    </div>
+    <div class="col-6">
+        <label for="deliveryAddress" class="form-label">Delivery Address <span class="text-danger" aria-hidden="true">*</span></label>
+        <input class="form-control"
+               id="deliveryAddress"
+               name="deliveryAddress"
+               th:field="*{deliveryAddress}"
+               required
+               aria-required="true"
+               th:classappend="${#fields.hasErrors('deliveryAddress')} ? 'is-invalid' : ''"/>
+        <div class="invalid-feedback"
+             id="deliveryAddressError"
+             th:if="${#fields.hasErrors('deliveryAddress')}"
+             th:errors="*{deliveryAddress}">
+            Incorrect data
+        </div>
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Place Order</button>
+    </div>
+</form>

--- a/src/main/resources/templates/partials/orders.html
+++ b/src/main/resources/templates/partials/orders.html
@@ -1,0 +1,4 @@
+<tr th:each="order : ${orders}">
+    <td><a th:href="${'/orders/'+order.orderNumber}" th:text="${order.orderNumber}">OrderNumber</a></td>
+    <td th:text="${order.status}">status</td>
+</tr>

--- a/src/main/resources/templates/partials/products.html
+++ b/src/main/resources/templates/partials/products.html
@@ -22,8 +22,7 @@
                            th:text="${'Price: $'+product.price}">product.price</p>
                     </div>
                     <div class="card-footer" style="background: transparent; border-top: 0;">
-                    <form method="post"
-                          th:action="${@environment.getProperty('orders.service.buy-url', 'http://localhost:8091/buy')}">
+                    <form method="post" th:action="@{/buy}">
                         <div class="d-grid gap-2">
                                 <input type="hidden" name="code" th:value="${product.code}"/>
                                 <button class="btn btn-primary" type="submit">Buy</button>

--- a/src/test/java/com/sivalabs/bookstore/orders/web/CartTemplateRenderingTests.java
+++ b/src/test/java/com/sivalabs/bookstore/orders/web/CartTemplateRenderingTests.java
@@ -1,0 +1,118 @@
+package com.sivalabs.bookstore.orders.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import nz.net.ultraq.thymeleaf.layoutdialect.LayoutDialect;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+
+class CartTemplateRenderingTests {
+
+    private static TemplateEngine templateEngine;
+
+    @BeforeAll
+    static void setupEngine() {
+        ClassLoaderTemplateResolver resolver = new ClassLoaderTemplateResolver();
+        resolver.setPrefix("templates/");
+        resolver.setSuffix(".html");
+        resolver.setTemplateMode(TemplateMode.HTML);
+        resolver.setCharacterEncoding("UTF-8");
+        resolver.setCacheable(false);
+
+        templateEngine = new TemplateEngine();
+        templateEngine.setTemplateResolver(resolver);
+        templateEngine.addDialect(new LayoutDialect());
+    }
+
+    @Test
+    void rendersEmptyCartMessageWhenNoItem() {
+        Context context = new Context();
+        context.setVariable("cart", new TestCart(null, BigDecimal.ZERO));
+
+        String html = templateEngine.process("partials/cart", context);
+
+        assertThat(html).contains("Your cart is empty");
+    }
+
+    @Test
+    void escapesCartItemFields() {
+        TestCartItem item =
+                new TestCartItem(
+                        "P-123",
+                        "<script>alert('xss')</script>",
+                        new BigDecimal("10.00"),
+                        2);
+        Context context = new Context();
+        context.setVariable(
+                "cart",
+                new TestCart(item, new BigDecimal("20.00")));
+
+        String html = templateEngine.process("partials/cart", context);
+
+        assertThat(html).contains("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;");
+        assertThat(html).doesNotContain("<script>alert('xss')</script>");
+    }
+
+    @Test
+    void rendersFallbackWhenCartMissing() {
+        Context context = new Context();
+        context.setVariable("cart", null);
+
+        String html = templateEngine.process("partials/cart", context);
+
+        assertThat(html).contains("We couldn't load your cart right now");
+    }
+
+    private static final class TestCart {
+        private final TestCartItem item;
+        private final BigDecimal totalAmount;
+
+        private TestCart(TestCartItem item, BigDecimal totalAmount) {
+            this.item = item;
+            this.totalAmount = totalAmount;
+        }
+
+        public TestCartItem getItem() {
+            return item;
+        }
+
+        public BigDecimal getTotalAmount() {
+            return totalAmount;
+        }
+    }
+
+    private static final class TestCartItem {
+        private final String code;
+        private final String name;
+        private final BigDecimal price;
+        private final Integer quantity;
+
+        private TestCartItem(String code, String name, BigDecimal price, Integer quantity) {
+            this.code = code;
+            this.name = name;
+            this.price = price;
+            this.quantity = quantity;
+        }
+
+        public String getCode() {
+            return code;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public BigDecimal getPrice() {
+            return price;
+        }
+
+        public Integer getQuantity() {
+            return quantity;
+        }
+    }
+}

--- a/src/test/java/com/sivalabs/bookstore/orders/web/OrderDetailsTemplateRenderingTests.java
+++ b/src/test/java/com/sivalabs/bookstore/orders/web/OrderDetailsTemplateRenderingTests.java
@@ -1,0 +1,165 @@
+package com.sivalabs.bookstore.orders.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import nz.net.ultraq.thymeleaf.layoutdialect.LayoutDialect;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+
+class OrderDetailsTemplateRenderingTests {
+
+    private static TemplateEngine templateEngine;
+
+    @BeforeAll
+    static void setupEngine() {
+        ClassLoaderTemplateResolver resolver = new ClassLoaderTemplateResolver();
+        resolver.setPrefix("templates/");
+        resolver.setSuffix(".html");
+        resolver.setTemplateMode(TemplateMode.HTML);
+        resolver.setCharacterEncoding("UTF-8");
+        resolver.setCacheable(false);
+
+        templateEngine = new TemplateEngine();
+        templateEngine.setTemplateResolver(resolver);
+        templateEngine.addDialect(new LayoutDialect());
+    }
+
+    @Test
+    void rendersFallbackWhenOrderMissing() {
+        Context context = new Context();
+        context.setVariable("order", null);
+
+        String html = templateEngine.process("order_details", context);
+
+        assertThat(html).contains("We couldn't find that order.");
+    }
+
+    @Test
+    void escapesOrderFieldsAndMarksInputsReadonlyForAccessibility() {
+        TestOrderItem item =
+                new TestOrderItem(
+                        "<script>item()</script>", new BigDecimal("12.50"), 1);
+        TestCustomer customer =
+                new TestCustomer(
+                        "<script>name()</script>",
+                        "customer@example.com",
+                        "1234567890");
+        Context context = new Context();
+        context.setVariable(
+                "order",
+                new TestOrder(
+                        "ORD-1",
+                        "PLACED",
+                        item,
+                        customer,
+                        "123 Main St",
+                        new BigDecimal("12.50")));
+
+        String html = templateEngine.process("order_details", context);
+
+        assertThat(html).contains("&lt;script&gt;item()&lt;/script&gt;");
+        assertThat(html).doesNotContain("<script>item()</script>");
+        assertThat(html).contains("aria-readonly=\"true\"");
+    }
+
+    private static final class TestOrder {
+        private final String orderNumber;
+        private final String status;
+        private final TestOrderItem item;
+        private final TestCustomer customer;
+        private final String deliveryAddress;
+        private final BigDecimal totalAmount;
+
+        private TestOrder(
+                String orderNumber,
+                String status,
+                TestOrderItem item,
+                TestCustomer customer,
+                String deliveryAddress,
+                BigDecimal totalAmount) {
+            this.orderNumber = orderNumber;
+            this.status = status;
+            this.item = item;
+            this.customer = customer;
+            this.deliveryAddress = deliveryAddress;
+            this.totalAmount = totalAmount;
+        }
+
+        public String getOrderNumber() {
+            return orderNumber;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public TestOrderItem getItem() {
+            return item;
+        }
+
+        public TestCustomer getCustomer() {
+            return customer;
+        }
+
+        public String getDeliveryAddress() {
+            return deliveryAddress;
+        }
+
+        public BigDecimal getTotalAmount() {
+            return totalAmount;
+        }
+    }
+
+    private static final class TestOrderItem {
+        private final String name;
+        private final BigDecimal price;
+        private final Integer quantity;
+
+        private TestOrderItem(String name, BigDecimal price, Integer quantity) {
+            this.name = name;
+            this.price = price;
+            this.quantity = quantity;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public BigDecimal getPrice() {
+            return price;
+        }
+
+        public Integer getQuantity() {
+            return quantity;
+        }
+    }
+
+    private static final class TestCustomer {
+        private final String name;
+        private final String email;
+        private final String phone;
+
+        private TestCustomer(String name, String email, String phone) {
+            this.name = name;
+            this.email = email;
+            this.phone = phone;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public String getPhone() {
+            return phone;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- escape all cart and order template fields, add null fallbacks, and improve accessibility for readonly and required inputs
- adjust the HTMX cart update form to resubmit with proper swap target and better UX defaults
- cover cart and order templates with rendering tests that assert escaping, fallbacks, and accessibility attributes

## Testing
- `./mvnw -ntp test` *(fails: wget could not download Maven wrapper distribution because outbound network access is blocked in the execution environment)*
- `mvn -ntp test` *(fails: dependency downloads blocked by network restrictions while resolving the Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cee35a24f08329a754f17834e6e01e