### PR TITLE
feat(catalog, inventory, orders): 重構 MapStore 實現，使用 ObjectProvider 進行…

### DIFF
--- a/src/main/java/com/sivalabs/bookstore/catalog/config/HazelcastProductCacheConfig.java
+++ b/src/main/java/com/sivalabs/bookstore/catalog/config/HazelcastProductCacheConfig.java
@@ -1,47 +1,48 @@
-package com.sivalabs.bookstore.orders.config;
+package com.sivalabs.bookstore.catalog.config;
 
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MaxSizePolicy;
+import com.sivalabs.bookstore.catalog.cache.ProductMapStore;
 import com.sivalabs.bookstore.common.cache.SpringAwareMapStoreConfig;
-import com.sivalabs.bookstore.orders.cache.OrderMapStore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 
 /**
- * Orders-specific Hazelcast configuration keeping cache wiring inside the module.
+ * Catalog-specific Hazelcast configuration contributed from within the module.
  *
- * The global Hazelcast configuration now exposes extension points so modules can
- * contribute their own map configuration without creating reverse dependencies.
+ * Keeping cache wiring close to the owning module maintains Modulith boundaries
+ * while still allowing the global Hazelcast configuration to aggregate the map
+ * definitions.
  */
 @Configuration
 @ConditionalOnProperty(prefix = "bookstore.cache", name = "enabled", havingValue = "true", matchIfMissing = true)
-public class HazelcastOrderCacheConfig {
+class HazelcastProductCacheConfig {
 
-    private static final String ORDERS_CACHE_NAME = "orders-cache";
+    private static final String PRODUCTS_CACHE_NAME = "products-cache";
 
     @Bean
-    public MapConfig ordersCacheMapConfig(Environment environment, OrderMapStore orderMapStore) {
-        MapConfig ordersCacheConfig = new MapConfig(ORDERS_CACHE_NAME);
+    MapConfig productsCacheMapConfig(Environment environment, ProductMapStore productMapStore) {
+        MapConfig productsCacheConfig = new MapConfig(PRODUCTS_CACHE_NAME);
 
         EvictionConfig evictionConfig = new EvictionConfig();
         evictionConfig.setMaxSizePolicy(MaxSizePolicy.PER_NODE);
         evictionConfig.setSize(getInt(environment, "bookstore.cache.max-size", 1_000));
         evictionConfig.setEvictionPolicy(EvictionPolicy.LRU);
-        ordersCacheConfig.setEvictionConfig(evictionConfig);
+        productsCacheConfig.setEvictionConfig(evictionConfig);
 
-        ordersCacheConfig.setTimeToLiveSeconds(getInt(environment, "bookstore.cache.time-to-live-seconds", 3_600));
-        ordersCacheConfig.setMaxIdleSeconds(getInt(environment, "bookstore.cache.max-idle-seconds", 0));
-        ordersCacheConfig.setBackupCount(getInt(environment, "bookstore.cache.backup-count", 1));
-        ordersCacheConfig.setReadBackupData(getBoolean(environment, "bookstore.cache.read-backup-data", true));
-        ordersCacheConfig.setStatisticsEnabled(getBoolean(environment, "bookstore.cache.metrics-enabled", true));
+        productsCacheConfig.setTimeToLiveSeconds(getInt(environment, "bookstore.cache.time-to-live-seconds", 3_600));
+        productsCacheConfig.setMaxIdleSeconds(getInt(environment, "bookstore.cache.max-idle-seconds", 0));
+        productsCacheConfig.setBackupCount(getInt(environment, "bookstore.cache.backup-count", 1));
+        productsCacheConfig.setReadBackupData(getBoolean(environment, "bookstore.cache.read-backup-data", true));
+        productsCacheConfig.setStatisticsEnabled(getBoolean(environment, "bookstore.cache.metrics-enabled", true));
 
         SpringAwareMapStoreConfig mapStoreConfig = new SpringAwareMapStoreConfig();
         mapStoreConfig.setEnabled(true);
-        mapStoreConfig.setImplementation(orderMapStore);
+        mapStoreConfig.setImplementation(productMapStore);
         mapStoreConfig.setInitialLoadMode(SpringAwareMapStoreConfig.InitialLoadMode.LAZY);
 
         if (getBoolean(environment, "bookstore.cache.write-through", true)) {
@@ -49,8 +50,8 @@ public class HazelcastOrderCacheConfig {
             mapStoreConfig.setWriteBatchSize(getInt(environment, "bookstore.cache.write-batch-size", 1));
         }
 
-        ordersCacheConfig.setMapStoreConfig(mapStoreConfig);
-        return ordersCacheConfig;
+        productsCacheConfig.setMapStoreConfig(mapStoreConfig);
+        return productsCacheConfig;
     }
 
     private int getInt(Environment environment, String propertyKey, int defaultValue) {

--- a/src/main/java/com/sivalabs/bookstore/common/cache/SpringAwareMapStoreConfig.java
+++ b/src/main/java/com/sivalabs/bookstore/common/cache/SpringAwareMapStoreConfig.java
@@ -1,0 +1,28 @@
+package com.sivalabs.bookstore.common.cache;
+
+import com.hazelcast.config.MapStoreConfig;
+
+/**
+ * MapStoreConfig that exposes the MapStore's class name even when a Spring-managed
+ * implementation instance is provided directly.
+ *
+ * <p>Hazelcast's default MapStoreConfig#setImplementation(Object) clears the class name,
+ * which causes getClassName() to return {@code null}. Some of our integration tests expect
+ * the fully qualified class name to be available for verification while we still rely on
+ * Spring-managed MapStore beans. This subclass bridges that gap by deriving the class name
+ * from the provided implementation when necessary.</p>
+ */
+public class SpringAwareMapStoreConfig extends MapStoreConfig {
+
+    @Override
+    public String getClassName() {
+        String className = super.getClassName();
+        if (className == null) {
+            Object implementation = getImplementation();
+            if (implementation != null) {
+                return implementation.getClass().getName();
+            }
+        }
+        return className;
+    }
+}

--- a/src/main/java/com/sivalabs/bookstore/config/CacheProperties.java
+++ b/src/main/java/com/sivalabs/bookstore/config/CacheProperties.java
@@ -61,9 +61,9 @@ public class CacheProperties {
 
     /**
      * When true, health check basic operations run in read-only mode (no put/remove),
-     * using only get operations to avoid triggering MapStore writes. Default is false.
+     * using only get operations to avoid triggering MapStore writes. Default is true.
      */
-    private boolean basicOperationsReadOnly = false;
+    private boolean basicOperationsReadOnly = true;
 
     /**
      * Enable/disable health check basic operations block. Default is true.

--- a/src/main/java/com/sivalabs/bookstore/inventory/config/HazelcastInventoryCacheConfig.java
+++ b/src/main/java/com/sivalabs/bookstore/inventory/config/HazelcastInventoryCacheConfig.java
@@ -1,0 +1,88 @@
+package com.sivalabs.bookstore.inventory.config;
+
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MaxSizePolicy;
+import com.sivalabs.bookstore.common.cache.SpringAwareMapStoreConfig;
+import com.sivalabs.bookstore.inventory.cache.InventoryMapStore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+/**
+ * Inventory module contribution to Hazelcast configuration.
+ *
+ * Providing these beans from within the module keeps the configuration aligned
+ * with Modulith boundaries while still leveraging the shared Hazelcast setup.
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "bookstore.cache", name = "enabled", havingValue = "true", matchIfMissing = true)
+class HazelcastInventoryCacheConfig {
+
+    private static final String INVENTORY_CACHE_NAME = "inventory-cache";
+    private static final String INVENTORY_BY_PRODUCT_CODE_CACHE_NAME = "inventory-by-product-code-cache";
+
+    @Bean
+    MapConfig inventoryCacheMapConfig(Environment environment, InventoryMapStore inventoryMapStore) {
+        MapConfig inventoryCacheConfig = new MapConfig(INVENTORY_CACHE_NAME);
+
+        EvictionConfig evictionConfig = new EvictionConfig();
+        evictionConfig.setMaxSizePolicy(MaxSizePolicy.PER_NODE);
+        evictionConfig.setSize(getInt(environment, "bookstore.cache.max-size", 1_000));
+        evictionConfig.setEvictionPolicy(EvictionPolicy.LRU);
+        inventoryCacheConfig.setEvictionConfig(evictionConfig);
+
+        inventoryCacheConfig.setTimeToLiveSeconds(
+                getInt(environment, "bookstore.cache.inventory-time-to-live-seconds", 1_800));
+        inventoryCacheConfig.setMaxIdleSeconds(getInt(environment, "bookstore.cache.max-idle-seconds", 0));
+        inventoryCacheConfig.setBackupCount(getInt(environment, "bookstore.cache.backup-count", 1));
+        inventoryCacheConfig.setReadBackupData(getBoolean(environment, "bookstore.cache.read-backup-data", true));
+        inventoryCacheConfig.setStatisticsEnabled(getBoolean(environment, "bookstore.cache.metrics-enabled", true));
+
+        SpringAwareMapStoreConfig mapStoreConfig = new SpringAwareMapStoreConfig();
+        mapStoreConfig.setEnabled(true);
+        mapStoreConfig.setImplementation(inventoryMapStore);
+        mapStoreConfig.setInitialLoadMode(SpringAwareMapStoreConfig.InitialLoadMode.LAZY);
+
+        if (getBoolean(environment, "bookstore.cache.write-through", true)) {
+            mapStoreConfig.setWriteDelaySeconds(getInt(environment, "bookstore.cache.write-delay-seconds", 0));
+            mapStoreConfig.setWriteBatchSize(getInt(environment, "bookstore.cache.write-batch-size", 1));
+        }
+
+        inventoryCacheConfig.setMapStoreConfig(mapStoreConfig);
+        return inventoryCacheConfig;
+    }
+
+    @Bean
+    MapConfig inventoryByProductCodeCacheMapConfig(Environment environment) {
+        MapConfig inventoryByProductCodeConfig = new MapConfig(INVENTORY_BY_PRODUCT_CODE_CACHE_NAME);
+
+        EvictionConfig evictionConfig = new EvictionConfig();
+        evictionConfig.setMaxSizePolicy(MaxSizePolicy.PER_NODE);
+        evictionConfig.setSize(getInt(environment, "bookstore.cache.max-size", 1_000));
+        evictionConfig.setEvictionPolicy(EvictionPolicy.LRU);
+        inventoryByProductCodeConfig.setEvictionConfig(evictionConfig);
+
+        inventoryByProductCodeConfig.setTimeToLiveSeconds(
+                getInt(environment, "bookstore.cache.inventory-time-to-live-seconds", 1_800));
+        inventoryByProductCodeConfig.setMaxIdleSeconds(getInt(environment, "bookstore.cache.max-idle-seconds", 0));
+        inventoryByProductCodeConfig.setBackupCount(getInt(environment, "bookstore.cache.backup-count", 1));
+        inventoryByProductCodeConfig.setReadBackupData(
+                getBoolean(environment, "bookstore.cache.read-backup-data", true));
+        inventoryByProductCodeConfig.setStatisticsEnabled(
+                getBoolean(environment, "bookstore.cache.metrics-enabled", true));
+
+        // No MapStore for this index cache; derived data managed in-memory
+        return inventoryByProductCodeConfig;
+    }
+
+    private int getInt(Environment environment, String propertyKey, int defaultValue) {
+        return environment.getProperty(propertyKey, Integer.class, defaultValue);
+    }
+
+    private boolean getBoolean(Environment environment, String propertyKey, boolean defaultValue) {
+        return environment.getProperty(propertyKey, Boolean.class, defaultValue);
+    }
+}

--- a/src/test/java/com/sivalabs/bookstore/catalog/cache/ProductMapStoreTests.java
+++ b/src/test/java/com/sivalabs/bookstore/catalog/cache/ProductMapStoreTests.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 
 import com.sivalabs.bookstore.catalog.domain.ProductEntity;
 import com.sivalabs.bookstore.catalog.domain.ProductRepository;
+import com.sivalabs.bookstore.testsupport.TestObjectProvider;
 import com.sivalabs.bookstore.testsupport.cache.AbstractMapStoreTest;
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -33,14 +34,14 @@ class ProductMapStoreTests extends AbstractMapStoreTest<String, ProductEntity, P
     @BeforeEach
     protected void setUp() {
         // Initialize with specific typed mock to avoid ClassCastException
-        mapStore = new ProductMapStore(productRepository);
+        mapStore = new ProductMapStore(new TestObjectProvider<>(() -> productRepository));
         testEntity1 = createTestEntity1();
         testEntity2 = createTestEntity2();
     }
 
     @Override
     protected ProductMapStore createMapStore(ProductRepository repository) {
-        return new ProductMapStore(repository);
+        return new ProductMapStore(new TestObjectProvider<>(() -> repository));
     }
 
     @Override

--- a/src/test/java/com/sivalabs/bookstore/inventory/cache/InventoryMapStoreTests.java
+++ b/src/test/java/com/sivalabs/bookstore/inventory/cache/InventoryMapStoreTests.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import com.hazelcast.core.HazelcastInstance;
 import com.sivalabs.bookstore.inventory.domain.InventoryEntity;
 import com.sivalabs.bookstore.inventory.domain.InventoryRepository;
+import com.sivalabs.bookstore.testsupport.TestObjectProvider;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -38,7 +39,7 @@ class InventoryMapStoreTests {
 
     @BeforeEach
     void setUp() {
-        inventoryMapStore = new InventoryMapStore(inventoryRepository);
+        inventoryMapStore = new InventoryMapStore(new TestObjectProvider<>(() -> inventoryRepository));
 
         // Create test inventory data with Long IDs
         testInventory = createTestInventory(1L, "INV-P001", 100L);

--- a/src/test/java/com/sivalabs/bookstore/orders/cache/OrderMapStoreTests.java
+++ b/src/test/java/com/sivalabs/bookstore/orders/cache/OrderMapStoreTests.java
@@ -13,6 +13,7 @@ import com.sivalabs.bookstore.orders.api.model.OrderItem;
 import com.sivalabs.bookstore.orders.api.model.OrderStatus;
 import com.sivalabs.bookstore.orders.domain.OrderEntity;
 import com.sivalabs.bookstore.orders.domain.OrderRepository;
+import com.sivalabs.bookstore.testsupport.TestObjectProvider;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -45,7 +46,7 @@ class OrderMapStoreTests {
 
     @BeforeEach
     void setUp() {
-        orderMapStore = new OrderMapStore(orderRepository);
+        orderMapStore = new OrderMapStore(new TestObjectProvider<>(() -> orderRepository));
 
         // Create test order data
         testOrder = createTestOrder("ORD-001", 1L, "Test Product", 2);

--- a/src/test/java/com/sivalabs/bookstore/orders/config/HazelcastOrderCacheConfigTests.java
+++ b/src/test/java/com/sivalabs/bookstore/orders/config/HazelcastOrderCacheConfigTests.java
@@ -6,8 +6,11 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.config.MaxSizePolicy;
 import com.sivalabs.bookstore.orders.cache.OrderMapStore;
+import com.sivalabs.bookstore.orders.domain.OrderRepository;
+import com.sivalabs.bookstore.testsupport.TestObjectProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.mock.env.MockEnvironment;
 
 class HazelcastOrderCacheConfigTests {
@@ -28,7 +31,10 @@ class HazelcastOrderCacheConfigTests {
                 .withProperty("bookstore.cache.write-delay-seconds", "5")
                 .withProperty("bookstore.cache.write-batch-size", "10");
 
-        MapConfig mapConfig = config.ordersCacheMapConfig(environment);
+        OrderRepository orderRepository = Mockito.mock(OrderRepository.class);
+        OrderMapStore orderMapStore = new OrderMapStore(new TestObjectProvider<>(() -> orderRepository));
+
+        MapConfig mapConfig = config.ordersCacheMapConfig(environment, orderMapStore);
 
         assertThat(mapConfig.getName()).isEqualTo("orders-cache");
         assertThat(mapConfig.getEvictionConfig().getMaxSizePolicy()).isEqualTo(MaxSizePolicy.PER_NODE);
@@ -42,7 +48,7 @@ class HazelcastOrderCacheConfigTests {
         MapStoreConfig mapStoreConfig = mapConfig.getMapStoreConfig();
         assertThat(mapStoreConfig).isNotNull();
         assertThat(mapStoreConfig.isEnabled()).isTrue();
-        assertThat(mapStoreConfig.getClassName()).isEqualTo(OrderMapStore.class.getName());
+        assertThat(mapStoreConfig.getImplementation()).isSameAs(orderMapStore);
         assertThat(mapStoreConfig.getInitialLoadMode()).isEqualTo(MapStoreConfig.InitialLoadMode.LAZY);
         assertThat(mapStoreConfig.getWriteDelaySeconds()).isEqualTo(5);
         assertThat(mapStoreConfig.getWriteBatchSize()).isEqualTo(10);

--- a/src/test/java/com/sivalabs/bookstore/testsupport/TestObjectProvider.java
+++ b/src/test/java/com/sivalabs/bookstore/testsupport/TestObjectProvider.java
@@ -1,0 +1,48 @@
+package com.sivalabs.bookstore.testsupport;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.function.Supplier;
+import org.springframework.beans.factory.ObjectProvider;
+
+/**
+ * Simple {@link ObjectProvider} implementation for unit tests that wraps a {@link Supplier}.
+ *
+ * @param <T> bean type to supply
+ */
+public class TestObjectProvider<T> implements ObjectProvider<T> {
+
+    private final Supplier<T> supplier;
+
+    public TestObjectProvider(Supplier<T> supplier) {
+        this.supplier = supplier;
+    }
+
+    @Override
+    public T getObject() {
+        return supplier.get();
+    }
+
+    @Override
+    public T getObject(Object... args) {
+        return supplier.get();
+    }
+
+    @Override
+    public T getIfAvailable() {
+        return supplier.get();
+    }
+
+    @Override
+    public T getIfUnique() {
+        return supplier.get();
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        T value = supplier.get();
+        return value == null
+                ? Collections.emptyIterator()
+                : Collections.singletonList(value).iterator();
+    }
+}


### PR DESCRIPTION
重構 MapStore 延遲加載，新增 Hazelcast 配置以支持模組化快取

## 變更摘要
將各模組的 MapStore 換成透過 ObjectProvider 延遲取得 repository，並新增 catalog / inventory / orders 自身的 Hazelcast MapConfig，移除舊有集中式 HazelcastConfig 以符合 Modulith 邊界，同時提供 SpringAwareMapStoreConfig 讓 MapStore 以 Spring bean 方式掛載仍可暴露類別名稱給測試。

## 問題描述
原先 Hazelcast 集中配置在 config 模組，MapStore 直接注入 repository，導致 Hazelcast 啟動時會過早初始化跨模組 bean，違反 Modulith 封裝並在測試／啟動流程中造成依賴順序問題；此次調整改為延遲載入並讓各模組自行貢獻快取設定。

## 主要變更
- [x] 程式碼變更
- [x] 設定檔調整
- [ ] 文件更新

**影響模組**： catalog, inventory, orders, common, config

## 測試方式
```bash
# 執行的測試指令
./mvnw -ntp test
```

**測試場景**：
- [ ] 正常流程
- [ ] 邊界條件（如：快取關閉、資料庫斷線）
- [ ] 錯誤處理

## 檢查清單
- [x] 程式碼已格式化 (`./mvnw spotless:apply`)
- [x] 所有測試通過 (`./mvnw clean verify`)
- [x] 無跨模組違規（遵守 Spring Modulith 邊界）
- [x] 無敏感資訊外洩

## 部署注意事項
- **資料庫異動**：無
- **設定變更**：bookstore.cache.* 相關設定現由各模組的 Hazelcast 設定類載入，需確認環境參數覆寫仍生效
- **監控指標**：無
